### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Publish to Docker registry
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: registry.datexis.com/ksachs/noderestserver:latest
           username: ${{ secrets.DOCKER_REGISTRY_USER }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore